### PR TITLE
Fix calculation in if statement

### DIFF
--- a/Src/stm32f3_velocity.cpp
+++ b/Src/stm32f3_velocity.cpp
@@ -36,10 +36,10 @@ int Stm32f3Velocity::periodic_calculate_velocity(void) {
     velocity = present_encoder_count - past_encoder_count;
 
     if(velocity > MAX_ENCODER_COUNT / 2) {
-        velocity -= MAX_ENCODER_COUNT;
+        velocity -= (MAX_ENCODER_COUNT + 1);
     }
     else if(velocity < -(MAX_ENCODER_COUNT / 2)) {
-        velocity += MAX_ENCODER_COUNT;
+        velocity += (MAX_ENCODER_COUNT + 1);
     }
 
     past_encoder_count = present_encoder_count;


### PR DESCRIPTION
if文の中の計算を修正した．具体的には
MAX_ENCODER_COUNT を (MAX_ENCODER_COUNT + 1) のように変更した．
エンコーダはMAX_ENCODER_COUNTの値になった後0に戻るので，
0からカウント値を増やしていって再び0に戻るまでにカウントされるパルス数は
(MAX_ENCODER_COUNT + 1) である．