### PR TITLE
Fix stm32f3_antiphase_pwm module

### DIFF
--- a/Src/stm32f3_antiphase_pwm.cpp
+++ b/Src/stm32f3_antiphase_pwm.cpp
@@ -19,12 +19,21 @@ Stm32f3AntiphasePwm::~Stm32f3AntiphasePwm() {
 }
 
 int Stm32f3AntiphasePwm::update_duty(double duty_rate){
-    if(duty_rate > 1) return 1;
+    int retval = 0;
+    
+    if(duty_rate > 1) {
+        duty_rate = 1;
+        retval = 1;
+    }
+    else if(duty_rate < -1) {
+        duty_rate = -1;
+        retval = 1;
+    }
     
     double difference;
     difference = PWM_DUTY_MAX * duty_rate;
     htim->Instance->CCR1 = PWM_DUTY_ZERO + difference;
     htim->Instance->CCR2 = PWM_DUTY_ZERO - difference;
 
-    return 0;
+    return retval;
 }


### PR DESCRIPTION
アンチフェーズPWMモジュールのupdate_duty関数を
修正した．duty_rateが1を超えたときはduty_rate
= 1として処理．duty_rateが-1を下回った時は，
duty_rate = -1として処理する．