### PR TITLE
Fix calculation of duty rate

### DIFF
--- a/Src/cppmain.cpp
+++ b/Src/cppmain.cpp
@@ -95,9 +95,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
             switch (motor_setup_data[i].control_mode)
             {
             case DUTY_RATE_MODE:
-                for (int i = 0; i < 2; i++) {
-                    duty_rate[i] = motor_control_data[i] / (double)MOTOR_CONTROL_DATA_MAX; 
-                }
+                duty_rate[i] = motor_control_data[i] / (double)MOTOR_CONTROL_DATA_MAX;
                 break;
             
             case PID_MODE:
@@ -110,9 +108,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
                 break;
 
             default:
-                for (int i = 0; i < 2; i++) {
-                    duty_rate[i] = 0;
-                }
+                duty_rate[i] = 0;
                 break;
             }
             


### PR DESCRIPTION
モーター_0とモーター_1で処理を分けるためのfor文をswitch文の中にも書いて
しまっていた．これでは処理を分けるためのfor文が2重になってしまうため，
switch文の中のfor文を削除した．ただし，case PID_MODEにおいては，
feature/pid-control-method-in-cppmainブランチで書き換えるため，このブ
ランチではそのままにする．